### PR TITLE
Remove group permission

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "require": {
         "drupal/group": "^3.0",
         "drupal/groupmedia": "^4.0@alpha",
-        "drupal/group_permissions":"^2.0@alpha",
         "drupal/search_api_solr": "^4.2"  
     },
     "authors": [

--- a/group_solr.info.yml
+++ b/group_solr.info.yml
@@ -6,5 +6,4 @@ package: 'Custom'
 dependencies:
   - group
   - groupmedia
-  - group_permissions
   - search_api_solr


### PR DESCRIPTION
The [Group Permission](https://www.drupal.org/project/group_permissions) has ongoing issues with the new version 2.0 , and 3.0 of Group module , so we're removing it as dependency.

Related issues: 
* https://www.drupal.org/project/group_permissions/issues/3368882
* https://www.drupal.org/project/group_permissions/issues/3327680 